### PR TITLE
Fix schedule alignment

### DIFF
--- a/_includes/cr/schedule.html
+++ b/_includes/cr/schedule.html
@@ -46,12 +46,12 @@
     <h3>Day 4. Apr 1st </h3>
     <table class="table table-striped">
       <tr> <td>09:00</td>  <td>Welcome</td> </tr>
-      <tr> <td>09:15</td>  <td>Modular Code</td> </tr>
+      <tr> <td>09:15</td>  <td>Writing Modular Code</td> </tr>
       <tr> <td>10:15</td>  <td>Coffee break</td> </tr>
-      <tr> <td>10:30</td>  <td>Modular Code</td> </tr>
-      <tr> <td>11:00</td>  <td>Testing</td> </tr>
+      <tr> <td>10:30</td>  <td>Writing Modular Code</td> </tr>
+      <tr> <td>11:00</td>  <td>Introduction to Testing in python</td> </tr>
       <tr> <td>11:30</td>  <td>Coffee break</td> </tr>
-      <tr> <td>11:45</td>  <td>Testing</td> </tr>
+      <tr> <td>11:45</td>  <td>Introduction to Testing in python</td> </tr>
       <tr> <td>12:45</td>  <td>Wrap-up</td> </tr>
       <tr> <td>13:00</td>  <td>END</td> </tr>
     </table>


### PR DESCRIPTION
This is an embarrassing fix for the alignment of the schedule. It turns out that the text in the table is centered and not left aligned. Instead of learning HTML I just changed the title of the testing lesson so that it is of the same length of the longest title in the other blocks... 😎 😇 